### PR TITLE
Removed yaml_files from get_project method

### DIFF
--- a/rpc_differ/rpc_differ.py
+++ b/rpc_differ/rpc_differ.py
@@ -267,16 +267,9 @@ def run_rpc_differ():
                                          role_yaml_latest,
                                          args.update)
 
-    # Get the list of OpenStack projects from newer commit and older commit.
-    yaml_files = [
-        'playbooks/defaults/repo_packages/openstack_services.yml',
-        'playbooks/defaults/repo_packages/openstack_other.yml'
-    ]
     project_yaml = osa_differ.get_projects(osa_repo_dir,
-                                           yaml_files,
                                            osa_old_commit)
     project_yaml_latest = osa_differ.get_projects(osa_repo_dir,
-                                                  yaml_files,
                                                   osa_new_commit)
 
     # Generate the project report.


### PR DESCRIPTION
In osa_differ version 0.1.1, yaml_files was removed
from the get_project method in favor of automatically
discovering yaml files in the OSA project. This commit
removes mention of yaml_files to comply with the new
method signature is osa_differ