### PR TITLE
Added newline before RPC and OSA role titles

### DIFF
--- a/rpc_differ/rpc_differ.py
+++ b/rpc_differ/rpc_differ.py
@@ -235,7 +235,7 @@ def run_rpc_differ():
     role_yaml_latest = osa_differ.get_roles(rpc_repo_dir, rpc_new_commit)
 
     # Generate the role report.
-    report_rst += ("RPC-OpenStack Roles\n"
+    report_rst += ("\nRPC-OpenStack Roles\n"
                    "-------------------")
     report_rst += osa_differ.make_report(storage_directory,
                                          role_yaml,
@@ -260,7 +260,7 @@ def run_rpc_differ():
     role_yaml_latest = osa_differ.get_roles(osa_repo_dir, osa_new_commit)
 
     # Generate the role report.
-    report_rst += ("OpenStack-Ansible Roles\n"
+    report_rst += ("\nOpenStack-Ansible Roles\n"
                    "-----------------------")
     report_rst += osa_differ.make_report(storage_directory,
                                          role_yaml,


### PR DESCRIPTION
This is to fix formatting issues when converting the
RST output to Markdown.

Fixes https://github.com/major/rpc_differ/issues/1