### PR TITLE
Ensure links go to commit

### DIFF
--- a/rpc_differ/templates/offline-repo-changes.j2
+++ b/rpc_differ/templates/offline-repo-changes.j2
@@ -19,12 +19,12 @@ RPC commits provided.
 {% endif %}
 
 {% if commits | length > 0 %}
-+-{{ '-' * (commit_base_url | length + 14) }}-+-{{ '-' * 80}}-+
++-{{ '-' * (commit_base_url | length + 62) }}-+-{{ '-' * 80}}-+
 {% for commit in commits if not commit.summary[0:7] == 'Merge "' %}
-| `{{ commit.hexsha[0:8] }} <{{ commit_base_url }}>`_ | {{ commit.summary[0:80].ljust(80) }} |
+| `{{ commit.hexsha[0:8] }} <{{ commit_base_url }}/commit/{{ commit.hexsha }}>`_ | {{ commit.summary[0:80].ljust(80) }} |
 {% if not loop.last %}
-+-{{ '-' * (commit_base_url | length + 14) }}-+-{{ '-' * 80}}-+
++-{{ '-' * (commit_base_url | length + 62) }}-+-{{ '-' * 80}}-+
 {% endif %}
 {% endfor %}
-+-{{ '-' * (commit_base_url | length + 14) }}-+-{{ '-' * 80}}-+
++-{{ '-' * (commit_base_url | length + 62) }}-+-{{ '-' * 80}}-+
 {% endif %}

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name='rpc_differ',
-    version='0.2.0',
+    version='0.2.1',
     author='Major Hayden',
     author_email='major@mhtx.net',
     description="Find changes between RPC-OpenStack revisions",


### PR DESCRIPTION
The links in the rpc-openstack diff table were linking to the project
rather than the commit. This patch ensures those links take viewers
straight to the commit instead.