### PR TITLE
RE-35 Fix release job after INTAKERPC-132

### DIFF
--- a/rpc_differ/rpc_differ.py
+++ b/rpc_differ/rpc_differ.py
@@ -137,7 +137,7 @@ def get_osa_commit(repo, ref):
     except IndexError:
         # This branch doesn't use a submodule for OSA
         # Pull the SHA out of functions.sh
-        quoted_re = re.compile('OSA_RELEASE:-"([^"]+)"')
+        quoted_re = re.compile('OSA_RELEASE:-?"?([^"}]+)["}]')
         functions_path = \
             "{}/scripts/functions.sh".format(repo.working_tree_dir)
         with open(functions_path, "r") as funcs:


### PR DESCRIPTION
INTAKERPC-321 included a refactor of scripts/functions.sh that broke
the regex used to extract the OSA SHA.
Can someone please tell me how this is better than a submodule?