### PR TITLE
Add option for rpc-product and update file lookup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ GitPython
 jinja2
 osa_differ>=0.0.6
 requests
+yaml


### PR DESCRIPTION
The Master branch of rpc-o has added an rpc-release file, this change
allows the RPC-Differ to extract data from the new release file and
lookup the RPC product information.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>