### PR TITLE
RE-1190 Use osa_differ's checkout function

### DIFF
--- a/rpc_differ/rpc_differ.py
+++ b/rpc_differ/rpc_differ.py
@@ -154,8 +154,7 @@ projects between two RPC-OpenStack revisions.
 
 def get_osa_commit(repo, ref, rpc_product=None):
     """Get the OSA sha referenced by an RPCO Repo."""
-    repo.head.reference = repo.commit(ref)
-    repo.head.reset(index=True, working_tree=True)
+    osa_differ.checkout(repo, ref)
 
     functions_path = os.path.join(repo.working_tree_dir,
                                   'scripts/functions.sh')


### PR DESCRIPTION
This function copes with branches, SHAs and tags. It also copes with
stale local branches. It should be used to prevent duplicating
this logic in rpc-differ.

Depends on https://github.com/rcbops/osa_differ/pull/19