### PR TITLE
RE-1190 Prepend origin remote for PR refs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name='rpc_differ',
-    version='0.3.7',
+    version='0.3.8',
     author='Major Hayden',
     author_email='major@mhtx.net',
     description="Find changes between RPC-OpenStack revisions",


### PR DESCRIPTION
Given that rpc_differ is used in PR's and the ref given
is not strictly a SHA, the current commit validation
fails.

In this patch we create a new function to validate/modify
the commit given, and re-arrange the repo preparation to
ensure that the commits are adjusted at the top of the
process and fed all the way down the chain.

Initially we try the ref and if it fails, we prepend
the ref with the remote 'origin' and try it again.