### PR TITLE
Add ability to override dependency versions

### DIFF
--- a/rpc_differ/rpc_differ.py
+++ b/rpc_differ/rpc_differ.py
@@ -124,6 +124,16 @@ projects between two RPC-OpenStack revisions.
         default=False,
         help="Fetch latest changes to repo",
     )
+    parser.add_argument(
+        '--version-mappings',
+        action=osa_differ.VersionMappingsAction,
+        help=(
+            "Map dependency versions in cases where the old version no longer "
+            "exists. The argument should be of the form "
+            "'repo-name;old-version1:new-version1;old-version2:new-version2'."
+        ),
+    )
+
     display_opts = parser.add_argument_group("Limit scope")
     display_opts.add_argument(
         "--skip-projects",
@@ -374,7 +384,8 @@ def run_rpc_differ():
     report_rst += osa_differ.make_report(storage_directory,
                                          role_yaml,
                                          role_yaml_latest,
-                                         args.update)
+                                         args.update,
+                                         args.version_mappings)
 
     report_rst += "\n"
 
@@ -431,7 +442,8 @@ def run_rpc_differ():
     report_rst += osa_differ.make_report(storage_directory,
                                          role_yaml,
                                          role_yaml_latest,
-                                         args.update)
+                                         args.update,
+                                         args.version_mappings)
 
     project_yaml = osa_differ.get_projects(osa_repo_dir,
                                            osa_old_commit)
@@ -444,7 +456,8 @@ def run_rpc_differ():
     report_rst += osa_differ.make_report(storage_directory,
                                          project_yaml,
                                          project_yaml_latest,
-                                         args.update)
+                                         args.update,
+                                         args.version_mappings)
 
     # Publish report according to the user's request.
     output = publish_report(report_rst,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from setuptools import setup
 required_packages = [
     "GitPython",
     "jinja2",
-    "osa_differ>=0.3.9",
+    "osa_differ>=0.3.10",
     "requests"
 ]
 
@@ -33,7 +33,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name='rpc_differ',
-    version='0.3.9',
+    version='0.3.10',
     author='Major Hayden',
     author_email='major@mhtx.net',
     description="Find changes between RPC-OpenStack revisions",


### PR DESCRIPTION
This change extends rpc-differ to support the osa-differ argument
--version-mappings which was introduced in version 0.3.10. It allows a
version mapping to be specified for a project or role. For example, if
the project foo is pinned to the version 1.0.0 in RPC-OpenStack and the
project removes the tag and replaces it with v1.0.0, without this change
the command will fail. To address this, this change would allow the
following the be specified `--version-mapping 'foo;1.0.0:v1.0.0'`. A new
commit-ish can be proposed to override the one specified in
RPC-OpenStack to allow rpc-differ to work with versions of RPC-OpenStack
that no longer specify valid project/role versions.

Version updated to 0.3.10 in preparation for a new release.

JIRA: RE-2208