### PR TITLE
Get the correct role requirements for comparison

### DIFF
--- a/rpc_differ/rpc_differ.py
+++ b/rpc_differ/rpc_differ.py
@@ -368,13 +368,13 @@ def run_rpc_differ():
     try:
         role_yaml_latest = osa_differ.get_roles(
             rpc_repo_dir,
-            rpc_old_commit,
+            rpc_new_commit,
             args.role_requirements
         )
     except IOError:
         role_yaml_latest = osa_differ.get_roles(
             rpc_repo_dir,
-            rpc_old_commit,
+            rpc_new_commit,
             ROLE_REQ_FILE
         )
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name='rpc_differ',
-    version='0.3.10',
+    version='0.3.11',
     author='Major Hayden',
     author_email='major@mhtx.net',
     description="Find changes between RPC-OpenStack revisions",


### PR DESCRIPTION
In [1] we mistakenly merged a commit which compared the old
role set to the same old role set, rather than the new set.

[1] https://github.com/rcbops/rpc_differ/commit/aed95e02159b36424f5c1e3201f607a4349fc7fe